### PR TITLE
fix: address line field name for sepa payments

### DIFF
--- a/nodes/EasyBill/EasyBill.node.ts
+++ b/nodes/EasyBill/EasyBill.node.ts
@@ -1312,7 +1312,7 @@ export class EasyBill implements INodeType {
 						creditorName: 'creditor_name',
 						debitorBic: 'debitor_bic',
 						debitorAddressLine1: 'debitor_address_line_1',
-						debitorAddressLine2: 'debitor_address_line2',
+						debitorAddressLine2: 'debitor_address_line_2',
 						debitorCountry: 'debitor_country',
 						remittanceInformation: 'remittance_information',
 						type: 'type',


### PR DESCRIPTION
Die Easybill Dokumentation https://www.easybill.de/api/#/sepa%20payment behauptet, dass das Feld `debitor_address_line2` heißt, in Wirklichkeit heißt es `debitor_address_line_2`