### PR TITLE
Pagination support for List SEPA Payments operation

### DIFF
--- a/nodes/EasyBill/EasyBill.node.ts
+++ b/nodes/EasyBill/EasyBill.node.ts
@@ -803,6 +803,7 @@ export class EasyBill implements INodeType {
 				/* ║  CREATE CUSTOMER GROUP  ║ */
 				/* ╚═════════════════════════╝ */
 				if (operation === 'createCustomerGroup') {
+					// Hole die Pflichtparameter und optionale Felder
 					const name = this.getNodeParameter('name', i) as string;
 					const number = this.getNodeParameter('number', i) as number;
 					const description = this.getNodeParameter('description', i) as string | undefined;

--- a/nodes/EasyBill/SEPAPayment/SEPAPaymentFields.ts
+++ b/nodes/EasyBill/SEPAPayment/SEPAPaymentFields.ts
@@ -22,35 +22,6 @@ export const sepaPaymentFields: INodeProperties[] = [
 	/* ║  GET SEPA PAYMENTS  ║ */
 	/* ╚══════════════════════╝ */
 	{
-		displayName: 'Limit',
-		name: 'limit',
-		type: 'number',
-		typeOptions: {
-			minValue: 1,
-		},
-		default: 50,
-		description: 'Max number of results to return',
-		displayOptions: {
-			show: {
-				resource: ['sepaPayment'],
-				operation: ['getSepaPayments'],
-			},
-		},
-	},
-	{
-		displayName: 'Page',
-		name: 'page',
-		type: 'number',
-		default: 1,
-		description: 'Starting page number for pagination',
-		displayOptions: {
-			show: {
-				resource: ['sepaPayment'],
-				operation: ['getSepaPayments'],
-			},
-		},
-	},
-	{
 		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',

--- a/nodes/EasyBill/SEPAPayment/SEPAPaymentFields.ts
+++ b/nodes/EasyBill/SEPAPayment/SEPAPaymentFields.ts
@@ -42,7 +42,7 @@ export const sepaPaymentFields: INodeProperties[] = [
 		name: 'page',
 		type: 'number',
 		default: 1,
-		description: 'Page number to return',
+		description: 'Starting page number for pagination',
 		displayOptions: {
 			show: {
 				resource: ['sepaPayment'],


### PR DESCRIPTION
The implementation of the "List SEPA Payments" operation now handles pagination so that all results are returned to the n8n user. Only the `document_id` filter (comma-separated list of IDs) is being exposed by the operation.